### PR TITLE
Fix RA input

### DIFF
--- a/src/RomanFov.vue
+++ b/src/RomanFov.vue
@@ -690,7 +690,8 @@ onMounted(() => {
       "zoomDeg": "zoomDeg",
       "rollDeg": "rollRad",
     };
-    for (const [queryParam, cameraParam] of Object.entries(paramNames)) {
+    for (const queryParam of Object.keys(paramNames)) {
+      const cameraParam = paramNames[queryParam];
       const valueString = query.get(queryParam);
       if (valueString == null) {
         continue;
@@ -842,13 +843,14 @@ function handlePositionGoToClick(isActive: Ref<boolean>) {
 }
 
 function parseRA(data: string): number {
-  const lower = data.toLowerCase();
+  const lower = data.trim().toLowerCase();
   let hours = false;
-  if (['h', ':', ' '].some(c => lower.indexOf(c))) {
-    hours = true;
+  if (['h', ':', ' '].some(c => lower.indexOf(c) !== -1)) {
+    hours = lower.indexOf('d') === -1; // a d means there was degrees in there
   }
+  
   let ra = Coordinates.parse(lower);
-  if (hours) {
+  if (hours && ra <= 24) {
     ra *= 15;
   }
   return ra;
@@ -858,7 +860,7 @@ function tryGoToSearchPosition(menuOpen: Ref<boolean>, instant: boolean = false)
   positionSearchError.value = null;
 
   const ra = parseRA(positionSearchRA.value ?? "");
-  const dec = Coordinates.parseDec(positionSearchDec.value);
+  const dec = Coordinates.parseDec(positionSearchDec.value ?? "");
 
   const raValid = !isNaN(ra);
   const decValid = !isNaN(dec);
@@ -904,12 +906,13 @@ function copyURLToClipboard() {
     .then(() => {
       snackbarColor.value = "success";
       snackbarMessage.value = "Shareable URL copied to clipboard";
+      snackbar.value = true;
     })
     .catch((_err) => {
       snackbarColor.value = "error";
       snackbarMessage.value = "Failed to copy share URL to clipboard";
-    })
-    .finally(() => snackbar.value = true);
+      snackbar.value = true;
+    });
 }
 
 watch(galactic, (gal: boolean) => {
@@ -931,8 +934,8 @@ function handleResolved(object: ResolvedObject) {
   const {raDeg, decDeg}  = object;
   console.log('Received', object);
   if (raDeg && decDeg) {
-    positionSearchRA.value = `${raDeg / 15}`;
-    positionSearchDec.value = `${decDeg}`;
+    positionSearchRA.value = `${raDeg.toFixed(7)}d`;
+    positionSearchDec.value = `${decDeg.toFixed(7)}d`;
   }
   handlePositionGoToClick(ref(true));
 }

--- a/src/shims-wwt.d.ts
+++ b/src/shims-wwt.d.ts
@@ -4,19 +4,24 @@ import { Color, RenderContext } from "@wwtelescope/engine";
 
 declare module "@wwtelescope/engine" {
 
-  export class Coordinates {
-    static parse(data: string): number;
-    static parseRA(ra: string, degrees: true): number;
-    static parseDec(dec: string): number;
+  // export class Coordinates {
+  //   static parse(data: string): number;
+  //   static parseRA(ra: string, degrees: true): number;
+  //   static parseDec(dec: string): number;
+  // }
+  export namespace Coordinates {
+    function parse(data: string): number;
+    function parseRA(ra: string, degrees: boolean): number;
+    function parseDec(dec: string): number;
   }
 
   export const ss;
 
   export class Matrix3d {}
 
-  export class Vector3d {
-    static create(x: number, y: number, z: number): Vector3d;
-  }
+  // export class Vector3d {
+  //   static create(x: number, y: number, z: number): Vector3d;
+  // }
 
   export class SimpleLineList {
     pure2D: boolean;


### PR DESCRIPTION
When a user entered a number like 266 for RA, it was getting interpreted as a number instead of a decimal degree. 
 - fix the hour marker check, to explicitly look for -1 return from indexOf
- The RA input box explicitly says it accept HMS or decimal degrees, but `handleResolved` was placing decimal hours in the box. Update it to be in degrees and append `d` to remove ambiguity
- fix a few typescript issues that probably came with an updated version